### PR TITLE
enabled new version check in wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dagcoin-tn",
   "description": "A wallet for decentralized value",
   "author": "Dagcoin",
-  "version": "1.0.0t",
+  "version": "1.1.0t",
   "keywords": [
     "wallet",
     "dagcoin",

--- a/src/js/controllers/newVersionIsAvailable.js
+++ b/src/js/controllers/newVersionIsAvailable.js
@@ -1,24 +1,25 @@
-// 'use strict';
-//
-// angular.module('copayApp.controllers').controller('newVersionIsAvailable', function($scope, $modalInstance, go, newVersion){
-//
-//  $scope.version = newVersion.version;
-//
-//  $scope.openDownloadLink = function(){
-//    var link = '';
-//    if (navigator && navigator.app) {
-//      link = 'https://play.google.com/store/apps/details?id=org.byteball.wallet';
-//	  if (newVersion.version.match('t$'))
-//		  link += '.testnet';
-//    }
-//    else {
-//      link = 'https://github.com/byteball/byteball/releases/tag/v' + newVersion.version;
-//    }
-//    go.openExternalLink(link);
-//    $modalInstance.close('closed result');
-//  };
-//
-//  $scope.later = function(){
-//    $modalInstance.close('closed result');
-//  };
-// });
+'use strict';
+
+angular.module('copayApp.controllers').controller('newVersionIsAvailable', function($scope, $modalInstance, go, newVersion){
+
+	$scope.version = newVersion.version;
+
+	$scope.openDownloadLink = function(){
+		var link = 'https://github.com/dagcoin/dagcoin/releases/tag/v' + newVersion.version;
+		// todo: comment out after we will have package on google play
+// 		if (navigator && navigator.app) {
+// 			link = 'https://play.google.com/store/apps/details?id=org.byteball.wallet';
+// 			if (newVersion.version.match('t$'))
+// 				link += '.testnet';
+// 		}
+// 		else {
+// 			link = 'https://github.com/byteball/byteball/releases/tag/v' + newVersion.version;
+// 		}
+		go.openExternalLink(link);
+		$modalInstance.close('closed result');
+	};
+
+	$scope.later = function(){
+		$modalInstance.close('closed result');
+	};
+});

--- a/src/js/services/newVersion.js
+++ b/src/js/services/newVersion.js
@@ -1,34 +1,35 @@
-// 'use strict';
-//
-// var eventBus = require('byteballcore/event_bus.js');
-//
-// angular.module('copayApp.services')
-// .factory('newVersion', function($modal, $timeout, $rootScope){
-//  var root = {};
-//  root.shown = false;
-//  root.timerNextShow = false;
-//
-//  eventBus.on('new_version', function(ws, data){
-//    root.version = data.version;
-//    if(!root.shown) {
-//      // var modalInstance = $modal.open({
-//      //     templateUrl: 'views/modals/newVersionIsAvailable.html',
-//      //     controller: 'newVersionIsAvailable'
-//      // });
-//      // $rootScope.$on('closeModal', function() {
-//      // 	  modalInstance.dismiss('cancel');
-//      // });
-//      root.shown = true;
-//      startTimerNextShow();
-//    }
-//  });
-//
-//  function startTimerNextShow(){
-//    if (root.timerNextShow) $timeout.cancel(root.timerNextShow);
-//    root.timerNextShow = $timeout(function(){
-//      root.shown = false;
-//    }, 1000 * 60 * 60 * 24);
-//  }
-//
-//  return root;
-// });
+'use strict';
+
+var eventBus = require('byteballcore/event_bus.js');
+
+angular.module('copayApp.services')
+.factory('newVersion', function($modal, $timeout, $rootScope){
+	var root = {};
+	root.shown = false;
+	root.timerNextShow = false;
+
+
+	eventBus.on('new_version_dagcoin', function(ws, data){
+		root.version = data.version;
+		if(!root.shown) {
+			var modalInstance = $modal.open({
+				templateUrl: 'views/modals/newVersionIsAvailable.html',
+				controller: 'newVersionIsAvailable'
+			});
+			$rootScope.$on('closeModal', function() {
+				modalInstance.dismiss('cancel');
+			});
+			root.shown = true;
+			startTimerNextShow();
+		}
+	});
+
+	function startTimerNextShow(){
+		if (root.timerNextShow) $timeout.cancel(root.timerNextShow);
+		root.timerNextShow = $timeout(function(){
+			root.shown = false;
+		}, 1000 * 60 * 60 * 24);
+	}
+
+	return root;
+});


### PR DESCRIPTION
closes #99 
in byteball new version event is fired from: https://github.com/byteball/byteball-hub/blob/b5e15426d35379b2c1572e7e20d551b8e30e0474/start.js#L12