### PR TITLE
Issue-264: Switching wallet while syncing full wallet loses syncing modal

### DIFF
--- a/src/js/controllers/index.js
+++ b/src/js/controllers/index.js
@@ -170,6 +170,7 @@
         self.syncProgress = '0% of new units';
       });
       eventBus.on('catchup_balls_left', (countLeft) => {
+        self.setOngoingProcess('Syncing', true);
         if (catchupBallsAtStart === -1) {
           catchupBallsAtStart = countLeft;
         }


### PR DESCRIPTION
closes #264 