### PR TITLE
Shows error on unlock wallet action if submitted password was incorrect

### DIFF
--- a/src/js/services/profileService.js
+++ b/src/js/services/profileService.js
@@ -619,21 +619,22 @@
     root.unlockFC = function (error, cb) {
       $log.debug('Wallet is encrypted');
       $rootScope.$emit('Local/NeedsPassword', false, error, (err2, password) => {
-        if (err2 || !password) {
+        if (err2 && !password) {
           return cb({
-            message: (err2 || gettext('Password needed')),
+            message: (gettext('Password needed')),
           });
         }
+
         const fc = root.focusedClient;
-        try {
-          fc.unlock(password);
-          breadcrumbs.add(`unlocked ${fc.credentials.walletId}`);
-        } catch (e) {
-          $log.debug(e);
-          return cb({
-            message: gettext('Wrong password'),
-          });
-        }
+          try {
+            fc.unlock(password);
+            breadcrumbs.add(`unlocked ${fc.credentials.walletId}`);
+          } catch (e) {
+            $log.debug(e);
+            return cb({
+              message: (gettext('Wrong password')),
+            });
+          }
         const autolock = () => {
           if (root.bKeepUnlocked) {
             console.log('keeping unlocked');
@@ -653,6 +654,7 @@
           }
         };
         $timeout(autolock, 30 * 1000);
+
         return cb();
       });
     };


### PR DESCRIPTION
Changes processing of the error on unlock wallet action keeping popup open and showing corresponding error when incorrect password was submitted.

## Description
Adds recursive call of the unlockFC function if incorrect password was submitted.

## Related Issue
Closes #481 

## Motivation and Context
Helps user to understand that wallet is not unlocked when incorrect password was submitted keeping enter password popup open and showing corresponding error.
