### PR TITLE
#535 - adjusts css to make single address wallet info message visible

### DIFF
--- a/public/views/preferences.html
+++ b/public/views/preferences.html
@@ -11,12 +11,12 @@
       <div class="value">{{index.alias||index.walletName}}</div>
       <i class="icon-arrow-right3 size-24 arrow-right"></i>
     </li>
-    <li style="padding: 13px 20px 5px">
-      <div class="right text-gray">
-          <switch ng-model="index.isSingleAddress" class="green right" data-disabled="numAddresses > 1 || numCosigners > 1"></switch>
-      </div>
+    <li style="padding: 13px 30px 5px; display: flex; flex-direction: column;">
       <div translate>Single address wallet</div>
-      <div class="value m10b p70r" style="word-break: initial;">
+      <div class="right text-gray">
+        <switch ng-model="index.isSingleAddress" class="green right" data-disabled="numAddresses > 1 || numCosigners > 1"></switch>
+      </div>
+      <div class="value m10b p70r" style="white-space: initial; text-align: left;">
         <span ng-if="!(numAddresses > 1 || numCosigners > 1)" translate>Single address wallets will not spawn new addresses for every transaction, change will always go to the one and only address the wallet contains.</span>
         <span ng-if="numAddresses > 1 || numCosigners > 1" translate>Wallet cannot be converted to single address wallet as it consists of multiple addresses or is multidevice</span>
       </div>


### PR DESCRIPTION
## Description
Adjusts css to make single address wallet info message visible

Closes #535 

## Motivation and Context
Solves the problem with unreadable single address wallet information message, which was hidden under a switch 

## Checklist:
- [x] My code follows the code style of this project.
- [x] All tests passed.