### PR TITLE
Added an external paymentId to dagcoin units

### DIFF
--- a/src/js/controllers/walletHome.js
+++ b/src/js/controllers/walletHome.js
@@ -721,7 +721,7 @@
           const address = form.address.$modelValue;
           const recipientDeviceAddress = assocDeviceAddressesByPaymentAddress[address];
           let amount = form.amount.$modelValue;
-          const paymentId = form.paymentId ? form.amount.$modelValue : null;
+          const paymentId = form.paymentId ? form.paymentId.$modelValue : null;
           // const paymentId = 1;
           let merkleProof = '';
           if (form.merkle_proof && form.merkle_proof.$modelValue) {

--- a/src/js/controllers/walletHome.js
+++ b/src/js/controllers/walletHome.js
@@ -721,6 +721,8 @@
           const address = form.address.$modelValue;
           const recipientDeviceAddress = assocDeviceAddressesByPaymentAddress[address];
           let amount = form.amount.$modelValue;
+          const paymentId = form.paymentId ? form.amount.$modelValue : null;
+          // const paymentId = 1;
           let merkleProof = '';
           if (form.merkle_proof && form.merkle_proof.$modelValue) {
             merkleProof = form.merkle_proof.$modelValue.trim();
@@ -923,6 +925,17 @@
                 }
 
                 paymentPromise.then(() => new Promise((resolve, reject) => {
+                  if (paymentId != null) {
+                    const objectHash = require('byteballcore/object_hash');
+                    const payload = JSON.stringify({ paymentId });
+                    opts.messages = [{
+                      app: 'text',
+                      payload_location: 'inline',
+                      payload_hash: objectHash.getBase64Hash(payload),
+                      payload
+                    }];
+                  }
+
                   console.log(`PAYMENT OPTIONS BEFORE: ${JSON.stringify(opts)}`);
                   useOrIssueNextAddress(fc.credentials.walletId, 0, (addressInfo) => {
                     opts.change_address = addressInfo.address;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the possibility to integrate merchants by adding an external payment id.

## Related Issue
Closes #554 

## Motivation and Context
Required in the scope of the merchant integration in partnership with Priit Kallas

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
